### PR TITLE
fix(getAndRemove): clean up with promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,12 +142,14 @@ exports.saveChanges = function (item, updates, onChange) {
 };
 
 function getAndRemove(db, id) {
-  return new Promise(function (fulfill) {
-    db.get(id).then(function (object) {
-      db.remove(object).then(fulfill);
-    }).catch(function () { // not found?
-      fulfill();
-    });
+  return db.get(id).then(function (object) {
+    return db.remove(object);
+  }).catch(function (err) {
+    // If the doc isn't found, no biggie. Else throw.
+    /* istanbul ignore if */
+    if (err.status !== 404) {
+      throw err;
+    }
   });
 }
 


### PR DESCRIPTION
Here's how I would rewrite `getAndRemove` using PouchDB's own promises. Note that instead of catching all errors, I'm explicitly catching only 404s. I have to ignore that statement in istanbul, since we can't really reproduce it unless there's a network failure or something like that.
