### PR TITLE
Override PouchDB.allDocs (issue #175)

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,9 +23,8 @@ function notDefined(obj) {
   return typeof obj === 'undefined';
 }
 
-exports.delta = new events.EventEmitter();
-
 exports.deltaInit = function () {
+  this.delta = new events.EventEmitter();
 
   // TODO: remove as not needed anymore, right?
   // this.on('created', function (object) {
@@ -160,12 +159,12 @@ function onCreate(db, object) {
     if (!exports.wasDeleted(id)) { // not previously deleted?
       if (doc.$deleted) { // deleted?
         exports.markDeletion(id);
-        exports.delta.emit('delete', id);
+        db.delta.emit('delete', id);
       } else if (doc.$id) { // update?
-        exports.delta.emit('update', doc);
+        db.delta.emit('update', doc);
       } else {
         doc.$id = id;
-        exports.delta.emit('create', doc);
+        db.delta.emit('create', doc);
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -140,7 +140,9 @@ function allDocs(baseFn, options, callback) {
 exports.all = function () {
   var db = this;
   return db.allDocs({include_docs: true}).then(function (doc) {
-    return doc.rows.map(function (el) { return el.doc; });
+    var docs = {};
+    doc.rows.forEach(function (el) { docs[el.doc.$id] = el.doc; });
+    return docs;
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -136,7 +136,9 @@ function allDocs(baseFn, options, callback) {
 
 exports.all = function () {
   var db = this;
-  return db.allDocs({include_docs: true});
+  return db.allDocs({include_docs: true}).then(function (doc) {
+    return doc.rows.map(el => el.doc);
+  });
 };
 
 var deletions = {};

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 'use strict';
 
-var Promise = require('bluebird');
+import Promise from 'bluebird';
 
-var events = require('events');
+import events from 'events';
+
+const exports = {};
 
 function empty(obj) {
   for (var i in obj) { // jshint unused:false
@@ -262,3 +264,5 @@ exports.cleanup = function () {
 if (typeof window !== 'undefined' && window.PouchDB) {
   window.PouchDB.plugin(exports);
 }
+
+export default exports.default;

--- a/index.js
+++ b/index.js
@@ -70,13 +70,13 @@ exports.mergeAll = function (doc) {
       deletions[el.doc.$id] = true;
     } else if (!deletions[el.doc.$id]) { // update before any deletion?
       if (docs[el.doc.$id]) { // exists?
-        docs[el.doc.$id] = exports.merge(docs[el.doc.$id], el.doc);
+        docs[el.doc.$id].doc = exports.merge(docs[el.doc.$id].doc, el.doc);
       } else {
-        docs[el.doc.$id] = el.doc;
+        docs[el.doc.$id] = el;
       }
     }
   });
-  return doc;
+  return Object.values(docs);
 }
 
 function save(db, doc) {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 'use strict';
 
-import Promise from 'bluebird';
+var Promise = require('bluebird');
 
-import events from 'events';
-
-const exports = {};
+var events = require('events');
 
 function empty(obj) {
   for (var i in obj) { // jshint unused:false
@@ -299,5 +297,3 @@ exports.default = function (PouchDB) {
   // Wrap in another function to get correct `this`
   PouchDB.prototype.allDocs = function(options, callback) { return allDocs.call(this, baseAllDocs, options, callback); }
 }
-
-export default exports.default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "delta-pouch",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Conflict-free collaborative editing for PouchDB",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I moved the logic from `.all` into `.mergeAll` and made it keep the input shape (i.e. {docs: {}, key: 123, value: {}} stays the same, instead of becoming {...docs}). This is useful because this is the format `.allDocs` expects I added an override for `.allDocs` so that 3rd party plugins could take advantage of delta pouch's system without having to know about how the documents are combined together. I also bumped the version to 2.0 since it modifies the prototype of PouchDB, and people might not be expecting that, just to be safe.

Closes #175 